### PR TITLE
Add Playwright E2E QA suites for Heads Up and Don't Forget pillar pages

### DIFF
--- a/e2e/07-heads-up-pillar.spec.ts
+++ b/e2e/07-heads-up-pillar.spec.ts
@@ -1,0 +1,231 @@
+import { expect, test } from '@playwright/test';
+
+
+const faqTitle = 'Does the USPS change of address service notify my personal contacts?';
+
+test.describe('Suite 7: Heads Up™ Pillar Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/heads-up');
+  });
+
+  test('7.1.1 page returns HTTP 200', async ({ page }) => {
+    const response = await page.goto('/heads-up');
+    expect(response?.status()).toBe(200);
+  });
+
+  test('7.1.2 dom content loads under 5 seconds', async ({ page }) => {
+    const started = Date.now();
+    await page.goto('/heads-up', { waitUntil: 'domcontentloaded' });
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  test('7.1.3 no console errors (desktop only)', async ({ page, browserName }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chrome' || browserName !== 'chromium');
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        const text = msg.text();
+        if (!/cdn|analytics|cors|googletagmanager|facebook/i.test(text)) errors.push(text);
+      }
+    });
+    await page.reload();
+    expect(errors).toEqual([]);
+  });
+
+  test('7.1.4 no horizontal scroll', async ({ page }) => {
+    const hasOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+    expect(hasOverflow).toBeFalsy();
+  });
+
+  test('7.2 SEO metadata and JSON-LD', async ({ page }) => {
+    await expect(page).toHaveTitle(/Heads Up.*AddressGenie/i);
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /USPS only forwards mail/i);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', 'https://addressgenie.co/heads-up');
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /Heads Up/i);
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', 'https://addressgenie.co/heads-up');
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(1);
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', /index.*follow/i);
+
+    const jsonLdScripts = await page.$$eval('script[type="application/ld+json"]', (scripts) =>
+      scripts.map((s) => {
+        try {
+          return JSON.parse(s.textContent || '{}');
+        } catch {
+          return {};
+        }
+      }),
+    );
+    const graph = (jsonLdScripts.find((s) => s['@graph'])?.['@graph'] as Array<Record<string, unknown>>) || [];
+    const types = graph.map((g) => g['@type']);
+    expect(types).toContain('WebPage');
+    const howTo = graph.find((g) => g['@type'] === 'HowTo') as { step?: unknown[]; description?: string } | undefined;
+    expect(howTo?.step?.length).toBe(4);
+    expect(howTo?.description || '').toContain('USPS');
+    expect(graph.find((g) => g['@type'] === 'Service' && g['price'] === '0')).toBeTruthy();
+    const faq = graph.find((g) => g['@type'] === 'FAQPage') as { mainEntity?: unknown[] } | undefined;
+    expect(faq?.mainEntity?.length).toBe(8);
+  });
+
+  test('7.3 hero content and CTA', async ({ page }, testInfo) => {
+    const hero = page.locator('section').first();
+    await expect(hero.getByRole('heading', { level: 1 })).toContainText('Tell Everyone You’re Moving');
+    await expect(page.getByText('Heads Up™ by AddressGenie')).toBeVisible();
+    await expect(page.getByText(/Gmail or Outlook/i)).toBeVisible();
+    await expect(page.getByText(/5 minutes/i)).toBeVisible();
+    for (const benefit of ['Import contacts', 'photo of your new home', 'Free forever']) {
+      await expect(page.getByText(benefit, { exact: false }).first()).toBeVisible();
+    }
+    await expect(page.getByRole('heading', { name: 'Create Your Free Account' })).toBeVisible();
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+    await expect(page.locator('input[name="firstName"]')).toBeVisible();
+    await expect(page.locator('input[name="lastName"]')).toBeVisible();
+    const submit = page.getByRole('button', { name: /Start Notifying My Contacts/i }).first();
+    await expect(submit).toBeVisible();
+    const bgColor = await submit.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bgColor).toMatch(/85,\s*196,\s*104|55c468/i);
+    await expect(page.getByRole('link', { name: /Privacy Policy/i }).first()).toHaveAttribute('href', '/privacy/policy');
+    await expect(page.getByRole('link', { name: /^Terms$/i }).first()).toHaveAttribute('href', '/terms');
+    await expect(page.getByRole('link', { name: /Already have an account\? Sign In/i })).toHaveAttribute('href', '/signin');
+
+    if (testInfo.project.name === 'desktop-chrome') {
+      const bgImage = await hero.evaluate((el) => {
+        const div = el.querySelector('div[style*="background-image"],div[style*="backgroundImage"]');
+        return div ? getComputedStyle(div).backgroundImage : '';
+      });
+      expect(bgImage).toContain('ag-heads-up-diametric-hero');
+    }
+    if (testInfo.project.name === 'mobile') {
+      const mobileHero = page.locator('div.lg\\:hidden[style*="background-image"], div.lg\\:hidden[style*="backgroundImage"]').first();
+      await expect(mobileHero).toBeVisible();
+      const bg = await mobileHero.evaluate((el) => getComputedStyle(el).backgroundImage);
+      expect(bg.toLowerCase()).toContain('portrait');
+    }
+  });
+
+  test('7.4 signed-in banner behavior', async ({ page }) => {
+    await expect(page.getByText('Already signed in')).toHaveCount(0);
+    await page.addInitScript(() => {
+      localStorage.setItem('checklist_session', JSON.stringify({ email: 'test@example.com', firstName: 'Test', authenticated: true }));
+    });
+    await page.goto('/heads-up');
+    await expect(page.getByText('Already signed in')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Portal → Heads Up/i })).toHaveAttribute('href', '/portal');
+  });
+
+  test('7.5/7.6 feature and how-it-works sections', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Why This Isn't Just Another 'We Moved' Card/i })).toBeVisible();
+    for (const title of ['One-Click Import', '5 Designed Themes', 'Personal Touch', 'Real-Time Tracking', 'Your Data Stays Yours', 'Always Free']) {
+      await expect(page.getByRole('heading', { name: title })).toBeVisible();
+    }
+    await expect(page.getByText(/CCPA/i)).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /How Heads Up™ Works/i })).toBeVisible();
+    for (const step of ['Import Contacts', 'Select Recipients', 'Pick a Design', 'Send & Track']) {
+      await expect(page.getByText(step).first()).toBeVisible();
+    }
+  });
+
+  test('7.7 e-card carousel interaction', async ({ page }, testInfo) => {
+    await expect(page.getByRole('heading', { name: /What Your Contacts Will See/i })).toBeVisible();
+    for (const theme of ['Classic Elegance', 'New Nest', 'Fresh Start', 'Cozy Home', 'Modern Minimal']) {
+      await expect(page.getByRole('button', { name: theme })).toBeVisible();
+    }
+    const ecardImg = page.locator('img[alt*="e-card design"], img[src*="/images/e_card_image/"]').first();
+    const initialSrc = await ecardImg.getAttribute('src');
+    await page.getByRole('button', { name: 'Fresh Start' }).click();
+    const newSrc = await ecardImg.getAttribute('src');
+    expect(newSrc).not.toEqual(initialSrc);
+    await expect(page.getByText('The Johnson Family')).toBeVisible();
+    await expect(page.getByText(/Hi Sarah/i)).toBeVisible();
+    await expect(page.getByText(/Boulder, CO 80301/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Save Our New Address/i })).toBeVisible();
+    await expect(page.getByText(/Heads Up™ by AddressGenie/i).last()).toBeVisible();
+    await expect(page.getByText('Optional')).toBeVisible();
+    if (testInfo.project.name !== 'mobile') {
+      await expect(page.getByText('Included').first()).toBeVisible();
+    }
+  });
+
+  test('7.8 to 7.11 content sections and FAQ legibility', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /50–200 People Need Your New Address/i })).toBeVisible();
+    await expect(page.getByText(/no government service/i)).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /People Are Only Half the Equation/i })).toBeVisible();
+    await expect(page.getByText("Notifies your people")).toBeVisible();
+    await expect(page.getByText('Tracks every task')).toBeVisible();
+    await expect(page.getByText('Updates every company')).toBeVisible();
+    await expect(page.getByRole('link', { name: /Start My Free Checklist/i })).toHaveAttribute('href', '/moving-checklist');
+    await expect(page.getByRole('link', { name: /See How AddressGenie Works/i }).first()).toHaveAttribute('href', '/');
+
+    const dfCard = page.getByText("Don't Forget").first().locator('..');
+    const border = await dfCard.evaluate((el) => getComputedStyle(el).borderColor);
+    expect(border).toMatch(/220.*75.*115|dc4b73/i);
+
+    await expect(page.getByRole('heading', { name: /Frequently Asked Questions About Moving Announcements/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: new RegExp(faqTitle, 'i') })).toBeVisible();
+    await page.getByRole('button', { name: /USPS change of address/i }).click();
+    const answerEl = page.getByRole('button', { name: /USPS change of address/i }).locator('..').locator('p').first();
+    const styles = await answerEl.evaluate((el) => ({
+      color: getComputedStyle(el).color,
+      fontSize: parseFloat(getComputedStyle(el).fontSize),
+    }));
+    const rgb = styles.color.match(/\d+/g)?.map(Number) || [];
+    expect(rgb[0]).toBeLessThan(150);
+    expect(styles.fontSize).toBeGreaterThanOrEqual(14);
+
+    await expect(page.getByRole('heading', { name: /Your People Deserve a Heads Up/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Email us/i })).toHaveAttribute('href', /mailto:support@addressgenie\.co/i);
+  });
+
+  test('7.12 form submission and redirect', async ({ page }) => {
+    await page.route('**/api/checklist/subscribe', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      expect(body.email).toBe('test@example.com');
+      expect(body.firstName).toBe('Jane');
+      await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+    });
+
+    await page.fill('input[name="email"]', 'test@example.com');
+    await page.fill('input[name="firstName"]', 'Jane');
+    await page.fill('input[name="lastName"]', 'Doe');
+    await page.getByRole('button', { name: /Start Notifying My Contacts/i }).first().click();
+    await page.waitForURL('**/checklist/check-email**');
+    expect(page.url()).toContain('email=test%40example.com');
+  });
+});
+
+test.describe('Cross-page tests', () => {
+  test('Cross-links and brand color consistency', async ({ page }) => {
+    await page.goto('/heads-up');
+    await expect(page.getByRole('link', { name: /Start My Free Checklist/i })).toHaveAttribute('href', '/moving-checklist');
+    await expect(page.getByRole('link', { name: /See How AddressGenie Works/i }).first()).toHaveAttribute('href', '/');
+    const headsUpCtaColor = await page.getByRole('button', { name: /Start Notifying My Contacts/i }).first().evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(headsUpCtaColor).toMatch(/85,\s*196,\s*104|55c468/i);
+
+    await page.goto('/moving-checklist');
+    await expect(page.getByRole('link', { name: /See How AddressGenie Works/i })).toHaveAttribute('href', '/');
+    await expect(page.getByRole('link', { name: /Heads Up™/i }).last()).toHaveAttribute('href', '/heads-up');
+
+    const footer = page.locator('footer');
+    await expect(footer.getByRole('link', { name: /Privacy Policy/i })).toBeVisible();
+  });
+
+  test('LLM-ingestion FAQ and schema consistency', async ({ page }) => {
+    await page.goto('/heads-up');
+    const faqButtons = page.locator('button:has(svg.lucide-chevron-down)');
+    const count = await faqButtons.count();
+    expect(count).toBe(8);
+    for (let i = 0; i < count; i++) await faqButtons.nth(i).click();
+    const answers = page.locator('button:has(svg.lucide-chevron-down) + div p');
+    for (let i = 0; i < await answers.count(); i++) {
+      const text = await answers.nth(i).textContent();
+      expect((text || '').split(/\s+/).length).toBeGreaterThan(50);
+    }
+
+    await page.goto('/moving-checklist');
+    const jsonLdScripts = await page.$$eval('script[type="application/ld+json"]', (scripts) => scripts.map((s) => s.textContent || ''));
+    expect(jsonLdScripts.join(' ')).toMatch(/HowTo/i);
+    expect(jsonLdScripts.join(' ')).toMatch(/USPS|moving|address/i);
+  });
+});

--- a/e2e/08-dont-forget-pillar.spec.ts
+++ b/e2e/08-dont-forget-pillar.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+
+test.describe("Suite 8: Don't Forget™ Pillar Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/moving-checklist');
+  });
+
+  test('8.1 page load/performance', async ({ page }, testInfo) => {
+    const response = await page.goto('/moving-checklist');
+    expect(response?.status()).toBe(200);
+    const start = Date.now();
+    await page.goto('/moving-checklist', { waitUntil: 'domcontentloaded' });
+    expect(Date.now() - start).toBeLessThan(5000);
+
+    if (testInfo.project.name === 'desktop-chrome') {
+      const errors: string[] = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'error' && !/cdn|analytics|cors/i.test(msg.text())) errors.push(msg.text());
+      });
+      await page.reload();
+      expect(errors).toEqual([]);
+    }
+
+    const hasOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+    expect(hasOverflow).toBeFalsy();
+  });
+
+  test('8.2 metadata and structured data', async ({ page }) => {
+    await expect(page).toHaveTitle(/Moving Checklist.*AddressGenie/i);
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /128 tasks/i);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', 'https://addressgenie.co/moving-checklist');
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(1);
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', /index.*follow/i);
+
+    const ld = await page.$$eval('script[type="application/ld+json"]', (scripts) => scripts.map((s) => s.textContent || ''));
+    const raw = ld.join(' ');
+    expect(raw).toMatch(/HowTo/);
+    expect(raw).toMatch(/FAQPage/);
+    expect(raw).toMatch(/P56D/);
+  });
+
+  test('8.3 hero section', async ({ page }, testInfo) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(/Moving.*Checklist/i);
+    await expect(page.getByText("Don't Forget™ by AddressGenie")).toBeVisible();
+    await expect(page.getByText(/128 tasks/i)).toBeVisible();
+    await expect(page.getByText(/8 weeks/i)).toBeVisible();
+    await expect(page.getByText(/Saves your progress/i)).toBeVisible();
+    await expect(page.getByText(/Free forever/i)).toBeVisible();
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Checklist/i }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: /Already have an account\? Access My Checklist/i })).toHaveAttribute('href', '/signin');
+
+    if (testInfo.project.name === 'desktop-chrome') {
+      const desktopBg = page.locator('div.hidden.lg\\:block[style*="background-image"],div.hidden.lg\\:block[style*="backgroundImage"]').first();
+      const bg = await desktopBg.evaluate((el) => getComputedStyle(el).backgroundImage);
+      expect(bg.toLowerCase()).toContain('dont-forget');
+      expect(bg.toLowerCase()).toContain('landscape');
+    }
+    if (testInfo.project.name === 'mobile') {
+      const mobileBg = page.locator('div.lg\\:hidden[style*="background-image"],div.lg\\:hidden[style*="backgroundImage"]').first();
+      const bg = await mobileBg.evaluate((el) => getComputedStyle(el).backgroundImage);
+      expect(bg.toLowerCase()).toContain('portrait');
+    }
+  });
+
+  test('8.4 to 8.10 sections, links, and submission', async ({ page }, testInfo) => {
+    await expect(page.getByRole('heading', { name: /Why This Isn't Just Another Moving Checklist/i })).toBeVisible();
+    for (const title of ['Access Anywhere', 'Personalized Timeline', 'Two Views', 'Optional Reminders', 'Download PDF', 'Always Free']) {
+      await expect(page.getByRole('heading', { name: title })).toBeVisible();
+    }
+    await expect(page.getByText(/syncs automatically/i)).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /128 Moving Tasks.*14 Categories/i })).toBeVisible();
+    for (const cat of ['USPS & Mail', 'Utilities & Services', 'Government & Legal', 'Insurance & Financial']) {
+      await expect(page.getByText(cat)).toBeVisible();
+    }
+
+    await expect(page.getByText(/USPS and 400\+ companies|4,000\+ organizations/i)).toBeVisible();
+    const cta = page.getByRole('link', { name: /See How AddressGenie Works/i });
+    await expect(cta).toHaveAttribute('href', '/');
+
+    await expect(page.getByRole('link', { name: /Heads Up™/i }).last()).toHaveAttribute('href', '/heads-up');
+    await expect(page.getByRole('link', { name: /Don't Forget™/i }).last()).toHaveAttribute('href', '/dont-forget');
+
+    if (testInfo.project.name === 'desktop-chrome') {
+      await expect(page.getByRole('link', { name: /Create Free Account/i })).toHaveAttribute('href', '/moving-checklist');
+      await expect(page.getByRole('link', { name: /Do It All/i })).toBeVisible();
+    }
+
+    await page.route('**/api/checklist/subscribe', async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+    });
+    await page.fill('input[name="email"]', 'test@example.com');
+    await page.fill('input[name="firstName"]', 'John');
+    await page.fill('input[name="lastName"]', 'Doe');
+    await page.getByRole('button', { name: /Checklist/i }).first().click();
+    await page.waitForURL('**/checklist/check-email**');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@storyblok/react": "^5.4.12",
@@ -23,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: 'https://www.addressgenie.co',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-chrome',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'tablet',
+      use: { ...devices['iPad (gen 7)'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+});


### PR DESCRIPTION
### Motivation
- Provide a repeatable Playwright end-to-end QA suite for the public pillar pages to validate layout, SEO/JSON-LD, interactive elements, form behavior, cross-sell links, and responsive design across desktop, tablet, and mobile viewports.
- Centralize automated checks that catch regressions in hero imagery, carousels, FAQ behavior, and form submission redirects for these high-traffic marketing pages.

### Description
- Add `playwright.config.ts` with `baseURL: 'https://www.addressgenie.co'`, tracing on failure, and three projects (`desktop-chrome`, `tablet`, `mobile`).
- Add `e2e/07-heads-up-pillar.spec.ts` which includes page-load/performance checks, SEO and JSON-LD parsing assertions, hero and form validations, signed-in banner behavior, feature/how-it-works/carousel checks, FAQ legibility/interaction, form submission mocking, and cross-page/LLM-ingestion checks.
- Add `e2e/08-dont-forget-pillar.spec.ts` which includes load/performance checks, metadata/structured-data assertions, hero imagery per viewport, feature/categories/cross-sell sections, navigation/footer link checks, and mocked form submission flow.
- Update `package.json` to add a `test:e2e` script (`playwright test`) and declare `@playwright/test` under `devDependencies` to document the runner requirement.

### Testing
- Ran linting with `npx eslint e2e/07-heads-up-pillar.spec.ts e2e/08-dont-forget-pillar.spec.ts playwright.config.ts` which passed without errors.
- Attempted to run `npm install` to fetch `@playwright/test`, but `npm install` failed due to registry access (HTTP 403) in this environment so the Playwright runner could not be executed here.
- Attempted `npx playwright test e2e/07-heads-up-pillar.spec.ts e2e/08-dont-forget-pillar.spec.ts` which could not run because the Playwright package was not available due to the same registry access restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c18d37c08326b45daf3946388021)